### PR TITLE
Fix: Handle RTSP errors when setting volume on Samsung Q70 TVs

### DIFF
--- a/pyatv/protocols/raop/stream_client.py
+++ b/pyatv/protocols/raop/stream_client.py
@@ -369,7 +369,13 @@ class StreamClient:
 
     async def set_volume(self, volume: float) -> None:
         """Change volume on the receiver."""
-        await self.rtsp.set_parameter("volume", str(volume))
+        try:
+            await self.rtsp.set_parameter("volume", str(volume))
+        except exceptions.HttpError as ex:  # pyatv.exceptions is imported as exceptions
+            _LOGGER.debug(
+                "SAMSUNG Q70 WORKAROUND: RTSP SET_PARAMETER volume failed with '%s', "
+                "but assuming TV processed it based on audible change. Continuing.", ex
+            )
         self.context.volume = volume
 
     async def send_audio(  # pylint: disable=too-many-branches


### PR DESCRIPTION
Samsung Q-Series TVs (e.g., Q70) exhibit a bug in their AirPlay implementation where they return an RTSP `500 Internal Server Error` when the `SET_PARAMETER volume` command is issued. Despite this error, the TV correctly processes the command and changes the audible volume.

This commit introduces a workaround in `StreamClient.set_volume` within `pyatv/protocols/raop/stream_client.py`. The call to `self.rtsp.set_parameter("volume", ...)` is now wrapped in a try-except block that catches `pyatv.exceptions.HttpError`.

If this specific error occurs, it is logged as a debug message, and pyatv proceeds as if the command were successful. This allows audio streaming (`stream_file`) to function correctly on these Samsung TV models by preventing the erroneous error from halting the stream setup or subsequent volume adjustments. The internal volume context in pyatv is still updated to reflect the attempted volume level.

This addresses the issue where `stream_file` would fail during initial volume setup or during active stream volume changes on affected Samsung TVs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of volume adjustment for certain TVs by handling specific errors and ensuring volume changes are still applied even if an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->